### PR TITLE
Report adapter info

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,9 +241,14 @@
     document.body.appendChild(elem);
   }
 
-  function adapterToElements(adapter) {
+  async function adapterToElements(adapter) {
+    const adapterInfo = await adapter.requestAdapterInfo();
     return el('table', {}, [
       el('tbody', {}, [
+      el('tr', {className: 'section'}, [
+          el('td', {colSpan: 2, textContent: 'adapter info:'}),
+        ]),
+        ...mapLikeToTableRows(adapterInfo),
         el('tr', {className: 'section'}, [
           el('td', {colSpan: 2, textContent: 'limits:'}),
         ]),
@@ -331,7 +336,7 @@
         // The id is the the actual adaptor limits as a string.
         // Effectively if the limits are the same then it's *probably* the 
         // same adaptor.
-        const elem = adapterToElements(adapter);
+        const elem = await adapterToElements(adapter);
         const id = elem.innerHTML + adapter.name;
         if (!adapterIds.has(id)) {
           adapterIds.set(id, {pref, elem, name: adapter.name});


### PR DESCRIPTION
Adds a section to the table which contains the adapter info reported by the browser. When requesting the adapter info no [unmaskHints ](https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestadapterinfo) are provided, as that may trigger a user consent dialog.

Thanks for publishing this page, by the way! It made debugging a recent Chrome change much easier!